### PR TITLE
Corrected the way header size and padding size are calculated

### DIFF
--- a/extract_blocks.py
+++ b/extract_blocks.py
@@ -58,7 +58,7 @@ for file in flist:                              # .raw files starting with argv 
                 nHeaderSize = nHeadLine*80      # size of header
         f.close()
 
-        nBlocs = numpy.ceil(os.path.getsize(file)/(nHeaderSize + nBlocsize))    # number of blocks in current file
+        nBlocs = np.ceil(os.path.getsize(file)/(nHeaderSize + nBlocsize))    # number of blocks in current file
         nTotalBlocs = nTotalBlocs + nBlocs      # total number of blocks
         nListBlocs.append(nBlocs)                       # lists number of blocks per file
         nListBlocsCumul.append(nTotalBlocs)     # lists number of cumulative blocks
@@ -108,26 +108,24 @@ nf = open(newfilename,'wb')     # open as [b]inary and to [w]rite
 for filenum in range(StartFile,StopFile+1):
         f = open(flist[filenum],'rb')
         if StartFile == StopFile:
-                for numblk in numpy.arange(StartBlock,StopBlock+1):
+                for numblk in np.arange(StartBlock,StopBlock+1):
                         f.seek(int(numblk*(nHeaderSize+nBlocsize)),0)
                         nf.write(f.read(int(nHeaderSize+nBlocsize)))
-                        # nf.write(numpy.fromfile(f, dtype=numpy.uint8, count=int(nHeaderSize+nBlocsize))
-        else:
+	else:
                 if filenum == StartFile:
                         for numblk in numpy.arange(StartBlock,nListBlocs[filenum]):
                                 f.seek(int(numblk*(nHeaderSize+nBlocsize)),0)
                                 nf.write(f.read(int(nHeaderSize+nBlocsize)))
-                                # nf.write(numpy.fromfile(f, dtype=numpy.uint8, count=int(nHeaderSize+nBlocsize))
-                elif filenum == StopFile:
+		elif filenum == StopFile:
                         for numblk in numpy.arange(0,StopBlock+1):
                                 f.seek(int(numblk*(nHeaderSize+nBlocsize)),0)
                                 nf.write(f.read(int(nHeaderSize+nBlocsize)))
-                                # nf.write(numpy.fromfile(f, dtype=numpy.uint8, count=int(nHeaderSize+nBlocsize))
                 else:
                         for numblk in numpy.arange(0,nListBlocs[filenum]):
                                 f.seek(int(numblk*(nHeaderSize+nBlocsize)),0)
                                 nf.write(f.read(int(nHeaderSize+nBlocsize)))
-                                # nf.write(numpy.fromfile(f, dtype=numpy.uint8, count=int(nHeaderSize+nBlocsize))
-        f.close()
+	f.close()
 
 nf.close()
+
+

--- a/extract_blocks.py
+++ b/extract_blocks.py
@@ -74,12 +74,13 @@ for file in flist:                              # .raw files starting with argv 
 
         # the header consists of N lines, each bytes_per_line long, and the last line should be "END" followed by 77 spaces.
         nHeaderSize = nHeadLine * bytes_per_line
-        
+
         # if directio is enabled, padding the header is (likely) required to
         # make nHeaderSize % direct_io_size == 0
-        if directio == 1:
-                nHeaderSize = direct_io_size * ( 1 + (nHeadLine * bytes_per_line) // direct_io_size )
-       
+        # padding not required if nHeaderSize % direct_io_size == 0
+        if directio == 1 and not (nHeaderSize % direct_io_size == 0):
+            nHeaderSize = direct_io_size * ( 1 + nHeaderSize // direct_io_size )
+        
         assert nHeaderSize == int(nHeaderSize)
         nHeaderSize = int(nHeaderSize)
         

--- a/extract_blocks.py
+++ b/extract_blocks.py
@@ -45,51 +45,51 @@ for file in flist:                              # .raw files starting with argv 
         
         nHeadLine = 0
         for i in range(max_header_lines):
-            currline = f.read(bytes_per_line)           
-            nHeadLine += 1 # increase nHeadLine counter
-            
-            # escape when end of header has been found
-            if currline.startswith('END'):
-                    break
+                currline = f.read(bytes_per_line)           
+                nHeadLine += 1 # increase nHeadLine counter
                 
-            # the header end should be reached before max_header_lines
-            if nHeadLine == max_header_lines - 1:
-                    sys.exit("""End of header not found within the first 300 lines.
-                             Are you sure you the files are correct and 
-                             you are calling this function with Python 2?""")
-            
-            subline = currline[value_start_idx:] # remove keyword from string
-            subline = subline.replace('"', '').replace("'", "").replace(' ', '') # clean string
-            
-            if ('BLOCSIZE' in subline):
-                    nBlocsize = int(subline) # convert string to integer
+                # escape when end of header has been found
+                if currline.startswith('END'):
+                        break
                     
-            if ('DIRECTIO' in subline):
-                    directio = int(subline) # convert string to integer
-                    
-            if ('CHAN_BW ' in subline):
-                    dchanbw = float(subline) # convert string to float
+                # the header end should be reached before max_header_lines
+                if nHeadLine == max_header_lines - 1:
+                        sys.exit("""End of header not found within the first 300 lines.
+                                 Are you sure you the files are correct and 
+                                 you are calling this function with Python 2?""")
+                
+                subline = currline[value_start_idx:] # remove keyword from string
+                subline = subline.replace('"', '').replace("'", "").replace(' ', '') # clean string
+                
+                if ('BLOCSIZE' in subline):
+                        nBlocsize = int(subline) # convert string to integer
+                        
+                if ('DIRECTIO' in subline):
+                        directio = int(subline) # convert string to integer
+                        
+                if ('CHAN_BW ' in subline):
+                        dchanbw = float(subline) # convert string to float
         
-            # the header consists of N lines, each bytes_per_line long, and the last line should be "END" followed by 77 spaces.
-            nHeaderSize = nHeadLine * bytes_per_line
-            
-            # if directio is enabled, padding the header is (likely) required to
-            # make nHeaderSize % direct_io_size == 0
-            if directio == 1:
-                    nHeaderSize = direct_io_size * np.ceil( (nHeadLine * bytes_per_line) / direct_io_size )
+        # the header consists of N lines, each bytes_per_line long, and the last line should be "END" followed by 77 spaces.
+        nHeaderSize = nHeadLine * bytes_per_line
+        
+        # if directio is enabled, padding the header is (likely) required to
+        # make nHeaderSize % direct_io_size == 0
+        if directio == 1:
+                nHeaderSize = direct_io_size * np.ceil( (nHeadLine * bytes_per_line) / direct_io_size )
           
-            f.close()
-            
-            assert nHeaderSize == int(nHeaderSize)
-            nHeaderSize = int(nHeaderSize)
-            
-            nBlocs = float(os.path.getsize(file)) / float(nHeaderSize + nBlocsize)
-            assert nBlocs == int(nBlocs)
-            nBlocs = int(nBlocs)
-            
-            nTotalBlocs = nTotalBlocs + nBlocs      # total number of blocks
-            nListBlocs.append(nBlocs)               # lists number of blocks per file
-            nListBlocsCumul.append(nTotalBlocs)     # lists number of cumulative blocks
+        f.close()
+        
+        assert nHeaderSize == int(nHeaderSize)
+        nHeaderSize = int(nHeaderSize)
+        
+        nBlocs = float(os.path.getsize(file)) / float(nHeaderSize + nBlocsize)
+        assert nBlocs == int(nBlocs)
+        nBlocs = int(nBlocs)
+        
+        nTotalBlocs = nTotalBlocs + nBlocs      # total number of blocks
+        nListBlocs.append(nBlocs)               # lists number of blocks per file
+        nListBlocsCumul.append(nTotalBlocs)     # lists number of cumulative blocks
 
 # print "# of blocs = ",nTotalBlocs
 # print "total duration = ",nTotalBlocs*nBlocsize/64./4./abs(dchanbw)/1e6," seconds"

--- a/extract_blocks.py
+++ b/extract_blocks.py
@@ -1,8 +1,12 @@
-import math, numpy, sys, os, glob, time, datetime
+#!/usr/bin/env python2
 
-def dm_delay(fl, fh, DM):
-    kdm = 4148.808 # MHz^2 / (pc cm^-3)
-    return abs(kdm * DM * (1.0 / (fl * fl) - 1 / (fh * fh)))
+# This script should be run with Python 2, and will fail with Python 3.
+
+import numpy as np
+import sys
+import os
+import glob
+
 
 
 if len(sys.argv) != 6:
@@ -49,7 +53,7 @@ for file in flist:                              # .raw files starting with argv 
                 currline = f.read(80)
                 nHeadLine = nHeadLine + 1                       # count number of lines in header
         if directio == 1:
-                nHeaderSize = 512*(math.floor((nHeadLine*80)/512.)+1)   # size of header
+                nHeaderSize = 512*(np.floor((nHeadLine*80)/512.)+1)   # size of header
         if directio == 0:
                 nHeaderSize = nHeadLine*80      # size of header
         f.close()
@@ -75,20 +79,20 @@ while nListBlocsCumul[idx]*nBlocsize/64./4./abs(dchanbw)/1e6 <= float(sys.argv[3
         idx = idx + 1
 StartFile = idx
 if StartFile == 0:
-        StartBlock = int(math.floor(float(sys.argv[3]) * nListBlocs[StartFile] / (nListBlocs[StartFile]*nBlocsize/64./4./abs(dchanbw)/1e6)))
+        StartBlock = int(np.floor(float(sys.argv[3]) * nListBlocs[StartFile] / (nListBlocs[StartFile]*nBlocsize/64./4./abs(dchanbw)/1e6)))
 else:
         timefile = float(sys.argv[3]) - nListBlocsCumul[idx-1]*nBlocsize/64./4./abs(dchanbw)/1e6
-        StartBlock = int(math.floor(timefile * nListBlocs[StartFile] / (nListBlocs[StartFile]*nBlocsize/64./4./abs(dchanbw)/1e6)))
+        StartBlock = int(np.floor(timefile * nListBlocs[StartFile] / (nListBlocs[StartFile]*nBlocsize/64./4./abs(dchanbw)/1e6)))
 
 idx = 0
 while nListBlocsCumul[idx]*nBlocsize/64./4./abs(dchanbw)/1e6 <= float(sys.argv[4]):
         idx = idx + 1
 StopFile = idx
 if StopFile == 0:
-        StopBlock = int(math.floor(float(sys.argv[4]) * nListBlocs[StopFile] / (nListBlocs[StopFile]*nBlocsize/64./4./abs(dchanbw)/1e6)))
+        StopBlock = int(np.floor(float(sys.argv[4]) * nListBlocs[StopFile] / (nListBlocs[StopFile]*nBlocsize/64./4./abs(dchanbw)/1e6)))
 else:
         timefile = float(sys.argv[4]) - nListBlocsCumul[idx-1]*nBlocsize/64./4./abs(dchanbw)/1e6
-        StopBlock = int(math.floor(timefile * nListBlocs[StopFile] / (nListBlocs[StopFile]*nBlocsize/64./4./abs(dchanbw)/1e6)))
+        StopBlock = int(np.floor(timefile * nListBlocs[StopFile] / (nListBlocs[StopFile]*nBlocsize/64./4./abs(dchanbw)/1e6)))
 
 print "copy starts with file #",StartFile," - block #",StartBlock
 print "copy stops with file #",StopFile," - block #",StopBlock

--- a/splicer_raw.py
+++ b/splicer_raw.py
@@ -5,68 +5,112 @@
 # example :  python raw_splicer.py "/datax2/greg_raw_splicer/RAWFILE2/" 2 "test.raw"
 
 import os
-import glob
 import sys
-import math
 import numpy
 
 os.chdir(sys.argv[1])
-list_files = os.listdir(sys.argv[1])	# list all files from the data set
-numfiles = len(list_files)				# counts number of files in dataset
+list_files = os.listdir(sys.argv[1])    # list all files from the data set
+list_files.sort()
+numfiles = len(list_files)                # counts number of files in dataset
 
 if numfiles == 0:
-	print("error : no file corresponding to the dataset indicated")
-	sys.exit()
+    print("error : no file corresponding to the dataset indicated")
+    sys.exit()
 else:
-	print "there are " + str(numfiles) + " files in the data set"
+    print "there are " + str(numfiles) + " files in the data set"
 
 idx = -1
-cenfreq = [0]*numfiles	# array of central frequencies to order files
-obsbw = [0]*numfiles	# array of bandwidths
-NumBlocs = [0]*numfiles	# array of number of blocks per raw file
+cenfreq = [0]*numfiles    # array of central frequencies to order files
+obsbw = [0]*numfiles    # array of bandwidths
+NumBlocs = [0]*numfiles    # array of number of blocks per raw file
+
+# empty list to store BANKNAM numbers
+banknamlist = []
+
+# There is no good reason on why the header should contain more than 300 lines
+max_header_lines = 300
+
+# set up standard values
+direct_io_size = 512 # bytes
+bytes_per_line = 80 # bytes
+value_start_idx = 10
 
 for fname in list_files:
-	idx = idx + 1
-	fread = open(fname,'rb')	# open first file of data set
-	currline = str(fread.read(80))		# reads first line
-	nHeaderLines = 1
-	while currline[0:3] != 'END':		# until reaching end of header
-		currline = str(fread.read(80))	# read new header line
-		if currline[0:9] == 'OBSFREQ =':	# read cenral frequency
-			cenfreq[idx] = float(currline[9:])
-		if currline[0:9] == 'OBSBW   =':	# read bandwidth
-			obsbw[idx] = float(currline[9:])
-		if currline[0:9] == 'OBSNCHAN=':	# read number of coarse channels
-			obsnchan = float(currline[9:])
-		if currline[0:9] == 'NBITS   =':	# read quantization
-			nbits = float(currline[9:])
-		if currline[0:9] == 'DIRECTIO=':	# read directio flag
-			ndirectio = float(currline[9:])
-		if currline[0:9] == 'BLOCSIZE=':	# read block size
-			nblocsize = float(currline[9:])
-		if currline[0:9] == 'PKTSIZE =':	# read packet size
-			nPktSize = float(currline[9:])
-		nHeaderLines = nHeaderLines + 1		# counts number of lines in header
-	fread.close()
-	nPadd = 0
-	if ndirectio == 1:
-		nPadd = int((math.floor(80.*nHeaderLines/512.)+1)*512 - 80*nHeaderLines)
-	statinfo = os.stat(fname)
-	NumBlocs[idx] = int(round(statinfo.st_size / (nblocsize + nPadd + 80*nHeaderLines)))
+    idx = idx + 1
+    fread = open(fname,'rb')    # open first file of data set
+
+    nHeaderLines = 0
+    for i in range(max_header_lines):
+        currline = str(fread.read(bytes_per_line))    # read new header line
+        nHeaderLines = nHeaderLines + 1     # counts number of lines in header
+
+        # escape when end of header has been found
+        if currline.startswith('END'):
+            break
+
+        # the header end should be reached before max_header_lines
+        if nHeaderLines == max_header_lines - 1:
+            sys.exit("""End of header not found within the first 300 lines.
+                        Are you sure you the files are correct and
+                        you are calling this function with Python 2?""")
+
+        subline = currline[value_start_idx:] # remove keyword from string
+        subline = subline.replace('"', '').replace("'", "").replace(' ', '') # clean string
+
+        if currline[0:9] == 'OBSFREQ =':    # read cenral frequency
+            cenfreq[idx] = float(subline)
+        if currline[0:9] == 'OBSBW   =':    # read bandwidth
+            obsbw[idx] = float(subline)
+        if currline[0:9] == 'OBSNCHAN=':    # read number of coarse channels
+            obsnchan = float(subline)
+        if currline[0:9] == 'NBITS   =':    # read quantization
+            nbits = float(subline)
+        if currline[0:9] == 'DIRECTIO=':    # read directio flag
+            ndirectio = float(subline)
+        if currline[0:9] == 'BLOCSIZE=':    # read block size
+            nblocsize = float(subline)
+        if currline[0:9] == 'PKTSIZE =':    # read packet size
+            nPktSize = float(subline)
+        if currline[0:9] == 'BANKNAM =':    # read banknam
+            banknamlist.append(subline)
+    fread.close()
+
+    # the header consists of N lines, each bytes_per_line long, and the last line should be "END" followed by 77 spaces.
+    nHeaderSize = nHeaderLines * bytes_per_line
+    nPadd = 0
+
+    # if directio is enabled, padding the header is (likely) required to
+    # make nHeaderSize % direct_io_size == 0
+    # padding not required if nHeaderSize % direct_io_size == 0
+    if ndirectio == 1 and not (nHeaderSize % direct_io_size == 0):
+        nHeaderSize_previous = nHeaderSize
+        nHeaderSize = direct_io_size * ( 1 + nHeaderSize // direct_io_size )
+        nPadd = nHeaderSize - nHeaderSize_previous
+        assert nPadd >= 0
+
+    statinfo = os.stat(fname)
+    nBlocks = float(statinfo.st_size) / float(nblocsize + nHeaderSize)
+    assert nBlocks == int(nBlocks)
+    nBlocks = int(nBlocks)
+    NumBlocs[idx] = nBlocks
+
+# create a string which contains which banknams were spliced together
+banknamlist = [str(x.replace("BLP", "").replace(" ", "").replace("'", "")) for x in banknamlist]
+banknamesstr = "".join(banknamlist)
 
 nChanSize = nblocsize/obsnchan
 TotCenFreq = sum(cenfreq) / float(len(cenfreq))
 TotBW = sum(obsbw)
 
 if int(sum(NumBlocs)/len(NumBlocs)) != int(NumBlocs[0]):
-	print("all files don''t have the same number of blocks...")
-	sys.exit()
+    print("all files don''t have the same number of blocks...")
+    sys.exit()
 else:
-	NumBlocsSpliced = NumBlocs[0]
+    NumBlocsSpliced = NumBlocs[0]
 
 IdxFiles = numpy.argsort(cenfreq)
 if TotBW < 0:
-	IdxFiles = IdxFiles[::-1]
+    IdxFiles = IdxFiles[::-1]
 
 TotBlocSize = int(nblocsize*len(IdxFiles))
 NewTotBlocSize = int(TotBlocSize / float(sys.argv[2]))
@@ -74,93 +118,100 @@ TotNumChann = int(obsnchan * len(IdxFiles))
 
 output_file = open(sys.argv[3],"wb")
 for nblock in range(int(NumBlocs[0])):
-	print "copy block #" + str(nblock+1) + "/" + str(int(NumBlocs[0]))
-	for nDivid in range(int(sys.argv[2])):
-		fread = open(list_files[0],'rb')	# open first file of data set
-		fread.seek(int(nblock*(80*nHeaderLines+nPadd+nblocsize)))	# goes to the header
-		currline = fread.read(80)
-		output_file.write(currline)
-		while str(currline[0:3]) != 'END':		# until reaching end of header
-			currline = fread.read(80)		# read new header line
-			if str(currline[0:9]) == 'BANKNAM =':
-				teststr = 'BANKNAM = ''BLP00-37'''
-				teststr = teststr + ' '*(80-len(teststr))
-				currline = teststr
-			if str(currline[0:9]) == 'OBSFREQ =':	# change central frequency value
-				NewVal = TotCenFreq
-				NewValStr = str(NewVal)
-				if len(NewValStr) > 20:
-					NewValStr = NewValStr[0:20]
-				teststr = currline[0:9] + ' '*(20+1-len(NewValStr)) + NewValStr
-				teststr = teststr + ' '*(80-len(teststr))
-				currline = teststr
-			if str(currline[0:9]) == 'OBSBW   =':	# change bandwidth value
-				NewVal = TotBW
-				NewValStr = str(NewVal)
-				if len(NewValStr) > 20:
-					NewValStr = NewValStr[0:20]
-				teststr = currline[0:9] + ' '*(20+1-len(NewValStr)) + NewValStr
-				teststr = teststr + ' '*(80-len(teststr))
-				currline = teststr
-			if str(currline[0:9]) == 'OBSNCHAN=':	# change number of coarse channels
-				NewVal = TotNumChann
-				NewValStr = str(NewVal)
-				if len(NewValStr) > 20:
-					NewValStr = NewValStr[0:20]
-				teststr = currline[0:9] + ' '*(20+1-len(NewValStr)) + NewValStr
-				teststr = teststr + ' '*(80-len(teststr))
-				currline = teststr
-			if str(currline[0:9]) == 'DIRECTIO=':	# change directio value
-				NewVal = 0
-				NewValStr = str(NewVal)
-				if len(NewValStr) > 20:
-					NewValStr = NewValStr[0:20]
-				teststr = currline[0:9] + ' '*(20+1-len(NewValStr)) + NewValStr
-				teststr = teststr + ' '*(80-len(teststr))
-				currline = teststr
-			if str(currline[0:9]) == 'BLOCSIZE=':	# change block size value
-				NewVal = int(NewTotBlocSize)
-				NewValStr = str(NewVal)
-				if len(NewValStr) > 20:
-					NewValStr = NewValStr[0:20]
-				teststr = currline[0:9] + ' '*(20+1-len(NewValStr)) + NewValStr
-				teststr = teststr + ' '*(80-len(teststr))
-				currline = teststr
-			if str(currline[0:9]) == 'NPKT    =':
-				NewVal = int(NewTotBlocSize/nPktSize)
-				NewValStr = str(NewVal)
-				if len(NewValStr) > 20:
-					NewValStr = NewValStr[0:20]
-				teststr = currline[0:9] + ' '*(20+1-len(NewValStr)) + NewValStr
-				teststr = teststr + ' '*(80-len(teststr))
-				currline = teststr
-			if str(currline[0:9]) == 'PKTIDX  =':
-				NewVal = TotBlocSize/nPktSize*nblock + NewTotBlocSize/nPktSize*nDivid
-				NewValStr = str(NewVal)
-				if len(NewValStr) > 20:
-					NewValStr = NewValStr[0:20]
-				teststr = currline[0:9] + ' '*(20+1-len(NewValStr)) + NewValStr
-				teststr = teststr + ' '*(80-len(teststr))
-				currline = teststr
-			if str(currline[0:9]) == 'PKTSTOP =':
-				NewVal = TotBlocSize/nPktSize*(NumBlocsSpliced-1) + NewTotBlocSize/nPktSize*(int(sys.argv[2])-1)
-				NewValStr = str(NewVal)
-				if len(NewValStr) > 20:
-					NewValStr = NewValStr[0:20]
-				teststr = currline[0:9] + ' '*(20+1-len(NewValStr)) + NewValStr
-				teststr = teststr + ' '*(80-len(teststr))
-				currline = teststr
-			output_file.write(currline)
-		for nChan in range(int(obsnchan)):
-			fread.seek(nblock*(nHeaderLines*80+nPadd+nblocsize)+nHeaderLines*80+nPadd+nChan*nChanSize+nDivid*nChanSize/int(sys.argv[2]))
-			tmpdata = fread.read(int(nChanSize/int(sys.argv[2])))	# read data block
-			output_file.write(tmpdata)	# write data block
-		fread.close()			# close current file
-		for nFile in range(1,numfiles):
-			fread = open(list_files[nFile],'rb')	# open file
-			for nChan in range(int(obsnchan)):
-				fread.seek(nblock*(nHeaderLines*80+nPadd+nblocsize)+nHeaderLines*80+nPadd+nChan*nChanSize+nDivid*nChanSize/int(sys.argv[2]))
-				tmpdata = fread.read(int(nChanSize/int(sys.argv[2])))	# read data block
-				output_file.write(tmpdata)	# write data block
-			fread.close()			# close current file
-output_file.close()
+    print "copy block #" + str(nblock+1) + "/" + str(int(NumBlocs[0]))
+    for nDivid in range(int(sys.argv[2])):
+        fread = open(list_files[0],'rb')    # open first file of data set
+        fread.seek(int(nblock*(bytes_per_line*nHeaderLines+nPadd+nblocsize)))    # goes to the header
+        currline = fread.read(bytes_per_line)
+        output_file.write(currline)
+        while str(currline[0:3]) != 'END':        # until reaching end of header
+            currline = fread.read(bytes_per_line)        # read new header line
+            if str(currline[0:9]) == 'BANKNAM =':
+                # write down which banks were spliced together.
+                # this might cause an issue if >30 banks are spliced together
+                teststr = 'BANKNAM = ''BLP{}'''.format(banknamesstr)
+                assert len(teststr) < bytes_per_line
+                teststr = teststr + ' '*(bytes_per_line-len(teststr))
+                currline = teststr
+            if str(currline[0:9]) == 'OBSFREQ =':    # change central frequency value
+                NewVal = TotCenFreq
+                NewValStr = str(NewVal)
+                if len(NewValStr) > 20:
+                    NewValStr = NewValStr[0:20]
+                teststr = currline[0:9] + ' '*(20+1-len(NewValStr)) + NewValStr
+                teststr = teststr + ' '*(bytes_per_line-len(teststr))
+                currline = teststr
+            if str(currline[0:9]) == 'OBSBW   =':    # change bandwidth value
+                NewVal = TotBW
+                NewValStr = str(NewVal)
+                if len(NewValStr) > 20:
+                    NewValStr = NewValStr[0:20]
+                teststr = currline[0:9] + ' '*(20+1-len(NewValStr)) + NewValStr
+                teststr = teststr + ' '*(bytes_per_line-len(teststr))
+                currline = teststr
+            if str(currline[0:9]) == 'OBSNCHAN=':    # change number of coarse channels
+                NewVal = TotNumChann
+                NewValStr = str(NewVal)
+                if len(NewValStr) > 20:
+                    NewValStr = NewValStr[0:20]
+                teststr = currline[0:9] + ' '*(20+1-len(NewValStr)) + NewValStr
+                teststr = teststr + ' '*(bytes_per_line-len(teststr))
+                currline = teststr
+            if str(currline[0:9]) == 'DIRECTIO=':    # change directio value
+                NewVal = 0
+                NewValStr = str(NewVal)
+                if len(NewValStr) > 20:
+                    NewValStr = NewValStr[0:20]
+                teststr = currline[0:9] + ' '*(20+1-len(NewValStr)) + NewValStr
+                teststr = teststr + ' '*(bytes_per_line-len(teststr))
+                currline = teststr
+            if str(currline[0:9]) == 'BLOCSIZE=':    # change block size value
+                NewVal = int(NewTotBlocSize)
+                NewValStr = str(NewVal)
+                if len(NewValStr) > 20:
+                    NewValStr = NewValStr[0:20]
+                teststr = currline[0:9] + ' '*(20+1-len(NewValStr)) + NewValStr
+                teststr = teststr + ' '*(bytes_per_line-len(teststr))
+                currline = teststr
+            if str(currline[0:9]) == 'NPKT    =':
+                NewVal = int(NewTotBlocSize/nPktSize)
+                NewValStr = str(NewVal)
+                if len(NewValStr) > 20:
+                    NewValStr = NewValStr[0:20]
+                teststr = currline[0:9] + ' '*(20+1-len(NewValStr)) + NewValStr
+                teststr = teststr + ' '*(bytes_per_line-len(teststr))
+                currline = teststr
+            if str(currline[0:9]) == 'PKTIDX  =':
+                NewVal = TotBlocSize/nPktSize*nblock + NewTotBlocSize/nPktSize*nDivid
+                NewValStr = str(NewVal)
+                if len(NewValStr) > 20:
+                    NewValStr = NewValStr[0:20]
+                teststr = currline[0:9] + ' '*(20+1-len(NewValStr)) + NewValStr
+                teststr = teststr + ' '*(bytes_per_line-len(teststr))
+                currline = teststr
+            if str(currline[0:9]) == 'PKTSTOP =':
+                NewVal = TotBlocSize/nPktSize*(NumBlocsSpliced-1) + NewTotBlocSize/nPktSize*(int(sys.argv[2])-1)
+                NewValStr = str(NewVal)
+                if len(NewValStr) > 20:
+                    NewValStr = NewValStr[0:20]
+                teststr = currline[0:9] + ' '*(20+1-len(NewValStr)) + NewValStr
+                teststr = teststr + ' '*(bytes_per_line-len(teststr))
+                currline = teststr
+            output_file.write(currline)
+        for nChan in range(int(obsnchan)):
+            fread.seek(nblock*(nHeaderLines*bytes_per_line+nPadd+nblocsize)+nHeaderLines*bytes_per_line+nPadd+nChan*nChanSize+nDivid*nChanSize/int(sys.argv[2]))
+            tmpdata = fread.read(int(nChanSize/int(sys.argv[2])))    # read data block
+            output_file.write(tmpdata)    # write data block
+        fread.close()            # close current file
+        for nFile in range(1,numfiles):
+            fread = open(list_files[nFile],'rb')    # open file
+            for nChan in range(int(obsnchan)):
+                fread.seek(nblock*(nHeaderLines*bytes_per_line+nPadd+nblocsize)+nHeaderLines*bytes_per_line+nPadd+nChan*nChanSize+nDivid*nChanSize/int(sys.argv[2]))
+                tmpdata = fread.read(int(nChanSize/int(sys.argv[2])))    # read data block
+                output_file.write(tmpdata)    # write data block
+
+            fread.close()            # close current file
+
+output_file.close() # close new file
+
+


### PR DESCRIPTION
Hi Greg, 

I use two of your scripts (extract_blocks.py and splicer_raw.py). While they worked for GBT BL baseband data that I previously used (https://ui.adsabs.harvard.edu/abs/2018ApJ...863....2G/abstract and https://ui.adsabs.harvard.edu/abs/2023NatAs...7.1486S/abstract), they didn't work for recent GBT BL baseband data. 

After consulting with David MacMahon I figured out that the way the header size (and therefore also the padding size) was calculated incorrectly.

if `DIRECTIO=1` then the header likely needs padding (unless the header consists of 32 lines, or an integer multiple of 32 lines, since `(32 * 80) % 512 = 0` (80 bytes per line in the header). 
What happens is that the last line of the header is "END" followed by 77 spaces. Only then if padding is required, because of `DIRECTIO=1`, is padding added.

I've also removed some unneeded lines and added a couple of safe-guards. Please let me know if you have any questions. 

It is likely that the other scrips in this repo also need some small changes to correct this, but I have not used those scripts myself so I've kept them as they were.

All the best,

Mark Snelders

